### PR TITLE
Don't install shutilwhich if python does not require the backport

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (
 install_requires = [
     'WebOb >= 1.2',
     'setuptools',
-    'shutilwhich',
+    'shutilwhich; python_version < "3.3"',
 ]
 
 tests_require = [
@@ -34,6 +34,7 @@ class PyTest(Command):
         import subprocess
         errno = subprocess.call([sys.executable, 'runtests.py'])
         raise SystemExit(errno)
+
 
 setup(
     name='fanstatic',


### PR DESCRIPTION
shutilwhich provides a backport of which for versions of python prior to 3.3 

Make the installation of this library dependant on the version of python in use
