### PR TITLE
Update home url in setup.py to be https

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     author_email='zope-dev@zope.dev',
     long_description=long_description,
     license='BSD',
-    url='http://fanstatic.org',
+    url='https://www.fanstatic.org',
     packages=find_packages('src'),
     package_dir={'': 'src'},
     zip_safe=False,


### PR DESCRIPTION
This may have been missed in 95771f606457916995d37d4b00926f04879abf07

And of course using `www` subdomain to avoid directing to a blog